### PR TITLE
Remove compiled files from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,6 +274,7 @@ FakesAssemblies/
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
 node_modules/
+dist/
 
 # Visual Studio 6 build log
 *.plg


### PR DESCRIPTION
Compiled files must not to be within the source control. To remove them add the `dist` directory to the `.gitignore` file